### PR TITLE
Potential issue in Zend/zend_builtin_functions.c: Unchecked return from initialization function

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -824,8 +824,8 @@ ZEND_FUNCTION(get_object_vars)
 				/* This case is only possible due to loopholes, e.g. ArrayObject */
 				zend_hash_index_add(Z_ARRVAL_P(return_value), num_key, value);
 			} else if (!is_dynamic && ZSTR_VAL(key)[0] == 0) {
-				const char *prop_name, *class_name;
-				size_t prop_len;
+				const char *prop_name = (void*)0, *class_name;
+				size_t prop_len = 0;
 				zend_unmangle_property_name_ex(key, &class_name, &prop_name, &prop_len);
 				/* We assume here that a mangled property name is never
 				 * numeric. This is probably a safe assumption, but


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**1 instance** of this defect were found in the following locations:

---
**Instance 1**
File : `Zend/zend_builtin_functions.c` 
Enclosing Function : `zif_get_object_vars@@16`
Function : `zend_unmangle_property_name_ex` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/Zend/zend_builtin_functions.c#L829
**Issue in**: _prop_len, prop_name_

**Code extract**:

```cpp
			} else if (!is_dynamic && ZSTR_VAL(key)[0] == 0) {
				const char *prop_name, *class_name;
				size_t prop_len;
				zend_unmangle_property_name_ex(key, &class_name, &prop_name, &prop_len); <------ HERE
				/* We assume here that a mangled property name is never
				 * numeric. This is probably a safe assumption, but
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
