### PR TITLE
Potential issue in ext/standard/http_fopen_wrapper.c: Unchecked return from initialization function

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -411,7 +411,7 @@ finish:
 
 	/* protocol version we are speaking */
 	if (context && (tmpzval = php_stream_context_get_option(context, "http", "protocol_version")) != NULL) {
-		char *protocol_version;
+		char *protocol_version = (void*)0;
 		spprintf(&protocol_version, 0, "%.1F", zval_get_double(tmpzval));
 
 		smart_str_appends(&req_buf, " HTTP/");


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**1 instance** of this defect were found in the following locations:

---
**Instance 1**
File : `ext/standard/http_fopen_wrapper.c` 
Enclosing Function : `php_stream_url_wrap_http_ex`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/http_fopen_wrapper.c#L415
**Issue in**: _protocol_version_

**Code extract**:

```cpp
	/* protocol version we are speaking */
	if (context && (tmpzval = php_stream_context_get_option(context, "http", "protocol_version")) != NULL) {
		char *protocol_version;
		spprintf(&protocol_version, 0, "%.1F", zval_get_double(tmpzval)); <------ HERE

		smart_str_appends(&req_buf, " HTTP/");
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
