### PR TITLE
Potential issue in ext/standard/info.c: Unchecked return from initialization function

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -260,7 +260,7 @@ char* php_get_windows_name()
 	OSVERSIONINFOEX osvi = EG(windows_version_info);
 	SYSTEM_INFO si;
 	DWORD dwType;
-	char *major = NULL, *sub = NULL, *retval;
+	char *major = NULL, *sub = NULL, *retval = (void*)0;
 
 	ZeroMemory(&si, sizeof(SYSTEM_INFO));
 
@@ -858,7 +858,7 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 
 		{
 			const zend_multibyte_functions *functions = zend_multibyte_get_functions();
-			char *descr;
+			char *descr = (void*)0;
 			if (functions) {
 				spprintf(&descr, 0, "provided by %s", functions->provider_name);
 			} else {


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**2 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `ext/standard/info.c` 
Enclosing Function : `php_get_windows_name`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/info.c#L590
**Issue in**: _retval_

**Code extract**:

```cpp
		return NULL;
	}

	spprintf(&retval, 0, "%s%s%s%s%s", major, sub?" ":"", sub?sub:"", osvi.szCSDVersion[0] != '\0'?" ":"", osvi.szCSDVersion); <------ HERE
	return retval;
}
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `ext/standard/info.c` 
Enclosing Function : `php_print_info`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/info.c#L863
**Issue in**: _descr_

**Code extract**:

```cpp
			const zend_multibyte_functions *functions = zend_multibyte_get_functions();
			char *descr;
			if (functions) {
				spprintf(&descr, 0, "provided by %s", functions->provider_name); <------ HERE
			} else {
				descr = estrdup("disabled");
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
