### PR TITLE
Potential issue in ext/standard/user_filters.c: Unchecked return from initialization function

### DIFF
--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -123,7 +123,7 @@ static void userfilter_dtor(php_stream_filter *thisfilter)
 {
 	zval *obj = &thisfilter->abstract;
 	zval func_name;
-	zval retval;
+	zval retval = {};
 
 	if (obj == NULL) {
 		/* If there's no object associated then there's nothing to dispose of */
@@ -259,7 +259,7 @@ static php_stream_filter *user_filter_factory_create(const char *filtername,
 	php_stream_filter *filter;
 	zval obj, zfilter;
 	zval func_name;
-	zval retval;
+	zval retval = {};
 	size_t len;
 
 	/* some sanity checks */


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**2 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `ext/standard/user_filters.c` 
Enclosing Function : `userfilter_dtor`
Function : `_call_user_function_impl` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/user_filters.c#L135
**Issue in**: _retval_

**Code extract**:

```cpp

	ZVAL_STRINGL(&func_name, "onclose", sizeof("onclose")-1);

	call_user_function(NULL, <------ HERE
			obj,
			&func_name,
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `ext/standard/user_filters.c` 
Enclosing Function : `user_filter_factory_create`
Function : `_call_user_function_impl` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/user_filters.c#L343
**Issue in**: _retval_

**Code extract**:

```cpp
	/* invoke the constructor */
	ZVAL_STRINGL(&func_name, "oncreate", sizeof("oncreate")-1);

	call_user_function(NULL, <------ HERE
			&obj,
			&func_name,
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
