### PR TITLE
Potential issue in ext/standard/var.c: Unchecked return from initialization function

### DIFF
--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -235,7 +235,7 @@ static void zval_array_element_dump(zval *zv, zend_ulong index, zend_string *key
 
 static void zval_object_property_dump(zend_property_info *prop_info, zval *zv, zend_ulong index, zend_string *key, int level) /* {{{ */
 {
-	const char *prop_name, *class_name;
+	const char *prop_name = (void*)0, *class_name = (void*)0;
 
 	if (key == NULL) { /* numeric key */
 		php_printf("%*c[" ZEND_LONG_FMT "]=>\n", level + 1, ' ', index);
@@ -438,8 +438,8 @@ static void php_object_element_export(zval *zv, zend_ulong index, zend_string *k
 {
 	buffer_append_spaces(buf, level + 2);
 	if (key != NULL) {
-		const char *class_name, *prop_name;
-		size_t prop_name_len;
+		const char *class_name, *prop_name = (void*)0;
+		size_t prop_name_len = 0;
 		zend_string *pname_esc;
 
 		zend_unmangle_property_name_ex(key, &class_name, &prop_name, &prop_name_len);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**9 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `ext/standard/var.c` 
Enclosing Function : `zval_object_property_dump`
Function : `zend_unmangle_property_name_ex` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L243
**Issue in**: _prop_name, class_name_

**Code extract**:

```cpp
	if (key == NULL) { /* numeric key */
		php_printf("%*c[" ZEND_LONG_FMT "]=>\n", level + 1, ' ', index);
	} else { /* string key */
		zend_unmangle_property_name(key, &class_name, &prop_name); <------ HERE
		php_printf("%*c[", level + 1, ' ');

```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `ext/standard/var.c` 
Enclosing Function : `php_object_element_export`
Function : `zend_unmangle_property_name_ex` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L445
**Issue in**: _prop_name_len, prop_name_

**Code extract**:

```cpp
		size_t prop_name_len;
		zend_string *pname_esc;

		zend_unmangle_property_name_ex(key, &class_name, &prop_name, &prop_name_len); <------ HERE
		pname_esc = php_addcslashes_str(prop_name, prop_name_len, "'\\", 2);

```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 3**
File : `ext/standard/var.c` 
Enclosing Function : `zif_var_export@@16`
Function : `zend_gc_delref` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L618
**Issue in**: __arr_

**Code extract**:

```cpp
	smart_str buf = {0};

	ZEND_PARSE_PARAMETERS_START(1, 2)
		Z_PARAM_ZVAL(var) <------ HERE
		Z_PARAM_OPTIONAL
		Z_PARAM_BOOL(return_output)
```

**How can I fix it?** 
Correct reference usage found in `ext/standard/var.c` at line `1091`.
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1091
**Code extract**:

```cpp
					--count;
				}
				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
				zend_release_properties(myht); <------ HERE
				return;
			}
```


---
**Instance 4**
File : `ext/standard/var.c` 
Enclosing Function : `zif_var_export@@16`
Function : `zend_gc_delref` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L620
**Issue in**: __arr_

**Code extract**:

```cpp
	ZEND_PARSE_PARAMETERS_START(1, 2)
		Z_PARAM_ZVAL(var)
		Z_PARAM_OPTIONAL
		Z_PARAM_BOOL(return_output) <------ HERE
	ZEND_PARSE_PARAMETERS_END();

```

**How can I fix it?** 
Correct reference usage found in `ext/standard/var.c` at line `1091`.
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1091
**Code extract**:

```cpp
					--count;
				}
				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
				zend_release_properties(myht); <------ HERE
				return;
			}
```


---
**Instance 5**
File : `ext/standard/var.c` 
Enclosing Function : `zif_serialize@@16`
Function : `zend_gc_delref` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1154
**Issue in**: __arr_

**Code extract**:

```cpp
	smart_str buf = {0};

	ZEND_PARSE_PARAMETERS_START(1, 1)
		Z_PARAM_ZVAL(struc) <------ HERE
	ZEND_PARSE_PARAMETERS_END();

```

**How can I fix it?** 
Correct reference usage found in `ext/standard/var.c` at line `1091`.
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1091
**Code extract**:

```cpp
					--count;
				}
				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
				zend_release_properties(myht); <------ HERE
				return;
			}
```


---
**Instance 6**
File : `ext/standard/var.c` 
Enclosing Function : `zif_unserialize@@16`
Function : `zend_gc_delref` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1293
**Issue in**: __arr_

**Code extract**:

```cpp
	HashTable *options = NULL;

	ZEND_PARSE_PARAMETERS_START(1, 2)
		Z_PARAM_STRING(buf, buf_len) <------ HERE
		Z_PARAM_OPTIONAL
		Z_PARAM_ARRAY_HT(options)
```

**How can I fix it?** 
Correct reference usage found in `ext/standard/var.c` at line `1091`.
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1091
**Code extract**:

```cpp
					--count;
				}
				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
				zend_release_properties(myht); <------ HERE
				return;
			}
```


---
**Instance 7**
File : `ext/standard/var.c` 
Enclosing Function : `zif_unserialize@@16`
Function : `zend_gc_delref` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1295
**Issue in**: __arr_

**Code extract**:

```cpp
	ZEND_PARSE_PARAMETERS_START(1, 2)
		Z_PARAM_STRING(buf, buf_len)
		Z_PARAM_OPTIONAL
		Z_PARAM_ARRAY_HT(options) <------ HERE
	ZEND_PARSE_PARAMETERS_END();

```

**How can I fix it?** 
Correct reference usage found in `ext/standard/var.c` at line `1091`.
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1091
**Code extract**:

```cpp
					--count;
				}
				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
				zend_release_properties(myht); <------ HERE
				return;
			}
```


---
**Instance 8**
File : `ext/standard/var.c` 
Enclosing Function : `zif_memory_get_usage@@16`
Function : `zend_gc_delref` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1308
**Issue in**: __arr_

**Code extract**:

```cpp

	ZEND_PARSE_PARAMETERS_START(0, 1)
		Z_PARAM_OPTIONAL
		Z_PARAM_BOOL(real_usage) <------ HERE
	ZEND_PARSE_PARAMETERS_END();

```

**How can I fix it?** 
Correct reference usage found in `ext/standard/var.c` at line `1091`.
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1091
**Code extract**:

```cpp
					--count;
				}
				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
				zend_release_properties(myht); <------ HERE
				return;
			}
```


---
**Instance 9**
File : `ext/standard/var.c` 
Enclosing Function : `zif_memory_get_peak_usage@@16`
Function : `zend_gc_delref` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1321
**Issue in**: __arr_

**Code extract**:

```cpp

	ZEND_PARSE_PARAMETERS_START(0, 1)
		Z_PARAM_OPTIONAL
		Z_PARAM_BOOL(real_usage) <------ HERE
	ZEND_PARSE_PARAMETERS_END();

```

**How can I fix it?** 
Correct reference usage found in `ext/standard/var.c` at line `1091`.
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L1091
**Code extract**:

```cpp
					--count;
				}
				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
				zend_release_properties(myht); <------ HERE
				return;
			}
```

