### PR TITLE
Potential issue in main/php_ini.c: Unchecked return from initialization function

### DIFF
--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -589,7 +589,7 @@ int php_init_config(void)
 		/* Otherwise search for php-%sapi-module-name%.ini file in search path */
 		if (!fp) {
 			const char *fmt = "php-%s.ini";
-			char *ini_fname;
+			char *ini_fname = (void*)0;
 			spprintf(&ini_fname, 0, fmt, sapi_module.name);
 			fp = php_fopen_with_path(ini_fname, "r", php_ini_search_path, &opened_path);
 			efree(ini_fname);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**1 instance** of this defect were found in the following locations:

---
**Instance 1**
File : `main/php_ini.c` 
Enclosing Function : `php_init_config`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/main/php_ini.c#L593
**Issue in**: _ini_fname_

**Code extract**:

```cpp
		if (!fp) {
			const char *fmt = "php-%s.ini";
			char *ini_fname;
			spprintf(&ini_fname, 0, fmt, sapi_module.name); <------ HERE
			fp = php_fopen_with_path(ini_fname, "r", php_ini_search_path, &opened_path);
			efree(ini_fname);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
