### PR TITLE
Potential issue in main/streams/userspace.c: Unchecked return from initialization function

### DIFF
--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -696,7 +696,7 @@ static ssize_t php_userstreamop_read(php_stream *stream, char *buf, size_t count
 static int php_userstreamop_close(php_stream *stream, int close_handle)
 {
 	zval func_name;
-	zval retval;
+	zval retval = {};
 	php_userstream_data_t *us = (php_userstream_data_t *)stream->abstract;
 
 	assert(us != NULL);
@@ -1412,7 +1412,7 @@ static ssize_t php_userstreamop_readdir(php_stream *stream, char *buf, size_t co
 static int php_userstreamop_closedir(php_stream *stream, int close_handle)
 {
 	zval func_name;
-	zval retval;
+	zval retval = {};
 	php_userstream_data_t *us = (php_userstream_data_t *)stream->abstract;
 
 	assert(us != NULL);
@@ -1438,7 +1438,7 @@ static int php_userstreamop_closedir(php_stream *stream, int close_handle)
 static int php_userstreamop_rewinddir(php_stream *stream, zend_off_t offset, int whence, zend_off_t *newoffs)
 {
 	zval func_name;
-	zval retval;
+	zval retval = {};
 	php_userstream_data_t *us = (php_userstream_data_t *)stream->abstract;
 
 	ZVAL_STRINGL(&func_name, USERSTREAM_DIR_REWIND, sizeof(USERSTREAM_DIR_REWIND)-1);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**3 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `main/streams/userspace.c` 
Enclosing Function : `php_userstreamop_close`
Function : `_call_user_function_impl` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/main/streams/userspace.c#L706
**Issue in**: _retval_

**Code extract**:

```cpp

	ZVAL_STRINGL(&func_name, USERSTREAM_CLOSE, sizeof(USERSTREAM_CLOSE)-1);

	call_user_function(NULL, <------ HERE
			Z_ISUNDEF(us->object)? NULL : &us->object,
			&func_name,
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `main/streams/userspace.c` 
Enclosing Function : `php_userstreamop_closedir`
Function : `_call_user_function_impl` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/main/streams/userspace.c#L1422
**Issue in**: _retval_

**Code extract**:

```cpp

	ZVAL_STRINGL(&func_name, USERSTREAM_DIR_CLOSE, sizeof(USERSTREAM_DIR_CLOSE)-1);

	call_user_function(NULL, <------ HERE
			Z_ISUNDEF(us->object)? NULL : &us->object,
			&func_name,
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 3**
File : `main/streams/userspace.c` 
Enclosing Function : `php_userstreamop_rewinddir`
Function : `_call_user_function_impl` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/main/streams/userspace.c#L1446
**Issue in**: _retval_

**Code extract**:

```cpp

	ZVAL_STRINGL(&func_name, USERSTREAM_DIR_REWIND, sizeof(USERSTREAM_DIR_REWIND)-1);

	call_user_function(NULL, <------ HERE
			Z_ISUNDEF(us->object)? NULL : &us->object,
			&func_name,
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
