### PR TITLE
Potential issue in sapi/cli/php_cli_server.c: Unchecked return from initialization function

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -662,7 +662,7 @@ static void sapi_cli_server_register_variable(zval *track_vars_array, const char
 static int sapi_cli_server_register_entry_cb(char **entry, int num_args, va_list args, zend_hash_key *hash_key) /* {{{ */ {
 	zval *track_vars_array = va_arg(args, zval *);
 	if (hash_key->key) {
-		char *real_key, *key;
+		char *real_key = (void*)0, *key;
 		uint32_t i;
 		key = estrndup(ZSTR_VAL(hash_key->key), ZSTR_LEN(hash_key->key));
 		for(i=0; i<ZSTR_LEN(hash_key->key); i++) {
@@ -708,20 +708,20 @@ static void sapi_cli_server_register_variables(zval *track_vars_array) /* {{{ */
 		}
 	}
 	{
-		char *tmp;
+		char *tmp = (void*)0;
 		spprintf(&tmp, 0, "PHP %s Development Server", PHP_VERSION);
 		sapi_cli_server_register_variable(track_vars_array, "SERVER_SOFTWARE", tmp);
 		efree(tmp);
 	}
 	{
-		char *tmp;
+		char *tmp = (void*)0;
 		spprintf(&tmp, 0, "HTTP/%d.%d", client->request.protocol_version / 100, client->request.protocol_version % 100);
 		sapi_cli_server_register_variable(track_vars_array, "SERVER_PROTOCOL", tmp);
 		efree(tmp);
 	}
 	sapi_cli_server_register_variable(track_vars_array, "SERVER_NAME", client->server->host);
 	{
-		char *tmp;
+		char *tmp = (void*)0;
 		spprintf(&tmp, 0, "%i",  client->server->port);
 		sapi_cli_server_register_variable(track_vars_array, "SERVER_PORT", tmp);
 		efree(tmp);
@@ -739,7 +739,7 @@ static void sapi_cli_server_register_variables(zval *track_vars_array) /* {{{ */
 		sapi_cli_server_register_variable(track_vars_array, "PATH_INFO", client->request.path_info);
 	}
 	if (client->request.path_info_len) {
-		char *tmp;
+		char *tmp = (void*)0;
 		spprintf(&tmp, 0, "%s%s", client->request.vpath, client->request.path_info);
 		sapi_cli_server_register_variable(track_vars_array, "PHP_SELF", tmp);
 		efree(tmp);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**6 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `sapi/cli/php_cli_server.c` 
Enclosing Function : `sapi_cli_server_register_entry_cb`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/sapi/cli/php_cli_server.c#L675
**Issue in**: _real_key_

**Code extract**:

```cpp
				key[i] = toupper(key[i]);
			}
		}
		spprintf(&real_key, 0, "%s_%s", "HTTP", key); <------ HERE
		if (strcmp(key, "CONTENT_TYPE") == 0 || strcmp(key, "CONTENT_LENGTH") == 0) {
			sapi_cli_server_register_variable(track_vars_array, key, *entry);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `sapi/cli/php_cli_server.c` 
Enclosing Function : `sapi_cli_server_register_variables`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/sapi/cli/php_cli_server.c#L712
**Issue in**: _tmp_

**Code extract**:

```cpp
	}
	{
		char *tmp;
		spprintf(&tmp, 0, "PHP %s Development Server", PHP_VERSION); <------ HERE
		sapi_cli_server_register_variable(track_vars_array, "SERVER_SOFTWARE", tmp);
		efree(tmp);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 3**
File : `sapi/cli/php_cli_server.c` 
Enclosing Function : `sapi_cli_server_register_variables`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/sapi/cli/php_cli_server.c#L718
**Issue in**: _tmp_

**Code extract**:

```cpp
	}
	{
		char *tmp;
		spprintf(&tmp, 0, "HTTP/%d.%d", client->request.protocol_version / 100, client->request.protocol_version % 100); <------ HERE
		sapi_cli_server_register_variable(track_vars_array, "SERVER_PROTOCOL", tmp);
		efree(tmp);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 4**
File : `sapi/cli/php_cli_server.c` 
Enclosing Function : `sapi_cli_server_register_variables`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/sapi/cli/php_cli_server.c#L725
**Issue in**: _tmp_

**Code extract**:

```cpp
	sapi_cli_server_register_variable(track_vars_array, "SERVER_NAME", client->server->host);
	{
		char *tmp;
		spprintf(&tmp, 0, "%i",  client->server->port); <------ HERE
		sapi_cli_server_register_variable(track_vars_array, "SERVER_PORT", tmp);
		efree(tmp);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 5**
File : `sapi/cli/php_cli_server.c` 
Enclosing Function : `sapi_cli_server_register_variables`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/sapi/cli/php_cli_server.c#L743
**Issue in**: _tmp_

**Code extract**:

```cpp
	}
	if (client->request.path_info_len) {
		char *tmp;
		spprintf(&tmp, 0, "%s%s", client->request.vpath, client->request.path_info); <------ HERE
		sapi_cli_server_register_variable(track_vars_array, "PHP_SELF", tmp);
		efree(tmp);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 6**
File : `sapi/cli/php_cli_server.c` 
Enclosing Function : `php_cli_server_log_response`
Function : `zend_spprintf` 
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/sapi/cli/php_cli_server.c#L1204
**Issue in**: _basic_buf_

**Code extract**:

```cpp
#endif

	/* basic */
	spprintf(&basic_buf, 0, "%s [%d]: %s %s", client->addr_str, status, SG(request_info).request_method, client->request.request_uri); <------ HERE
	if (!basic_buf) {
		return;
```

**How can I fix it?** 
Correct reference usage found in `ext/standard/var.c` at line `579`.
https://github.com/siva-msft/php-src/blob/22982eee339c4983c87cea5d59aaf48601ad7030/ext/standard/var.c#L579
**Code extract**:

```cpp
				zend_release_properties(myht);
			}
			if (level > 1) {
				buffer_append_spaces(buf, level - 1); <------ HERE
			}
			if (Z_OBJCE_P(struc) == zend_standard_class_def) {
```

